### PR TITLE
Improve SVG accessibility

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -29,7 +29,16 @@ export const Header: React.FC = () => {
         >
           <UserCircleIcon className="w-8 h-8 text-gray-600 dark:text-slate-400" />
           <span className="text-sm font-medium text-gray-900 dark:text-slate-200 hidden md:block">{user?.username} ({user?.role})</span>
-           <svg className={`w-4 h-4 text-gray-600 dark:text-slate-400 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+           <svg
+             className={`w-4 h-4 text-gray-600 dark:text-slate-400 transition-transform ${dropdownOpen ? 'rotate-180' : ''}`}
+             xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewBox="0 0 24 24"
+             strokeWidth="1.5"
+             stroke="currentColor"
+             aria-hidden="true"
+             focusable="false"
+           >
             <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
           </svg>
         </button>

--- a/components/ui/Alert.tsx
+++ b/components/ui/Alert.tsx
@@ -23,25 +23,61 @@ export const Alert: React.FC<AlertProps> = ({ type = 'info', message, onClose, c
     switch (type) {
       case 'success':
         return (
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={iconClass}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className={iconClass}
+            aria-hidden="true"
+            focusable="false"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         );
       case 'error':
         return (
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={iconClass}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className={iconClass}
+            aria-hidden="true"
+            focusable="false"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
           </svg>
         );
       case 'warning':
          return (
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={iconClass}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className={iconClass}
+            aria-hidden="true"
+            focusable="false"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
           </svg>
         );
       default: // Info
         return (
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={iconClass}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className={iconClass}
+            aria-hidden="true"
+            focusable="false"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
           </svg>
         );
@@ -65,7 +101,16 @@ export const Alert: React.FC<AlertProps> = ({ type = 'info', message, onClose, c
                         `} 
             aria-label="Cerrar"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-5 h-5"
+            aria-hidden="true"
+            focusable="false"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -31,7 +31,16 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, 
               className="text-gray-400 dark:text-slate-400 hover:text-gray-600 dark:hover:text-slate-200 transition-colors"
               aria-label="Cerrar modal"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="w-6 h-6"
+                aria-hidden="true"
+                focusable="false"
+              >
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>


### PR DESCRIPTION
## Summary
- add aria-hidden and focusable attributes to decorative `<svg>`s in Modal
- make alert icons and close button hidden from assistive tech
- hide header dropdown arrow from screen readers

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d21f6f020832e82554723436f574a