### PR TITLE
Center pages with MainContainer wrapper

### DIFF
--- a/components/layout/MainContainer.tsx
+++ b/components/layout/MainContainer.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+
+interface MainContainerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export const MainContainer: React.FC<MainContainerProps> = ({ children, className = '' }) => {
+  return (
+    <div className={`max-w-7xl mx-auto px-4 ${className}`}>
+      {children}
+    </div>
+  );
+};
+
+MainContainer.displayName = 'MainContainer';

--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../hooks/useAuth';
 import { Card } from '../components/ui/Card';
 import { CubeIcon, DocumentTextIcon, UsersIcon, TruckIcon, IdentificationIcon, ClipboardDocumentListIcon } from '../constants';
 import { Link } from 'react-router-dom';
+import { MainContainer } from '../components/layout/MainContainer';
 import { MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_DOCUMENTS, MOCK_USERS, MOCK_CONSUMPTIONS, MOCK_PROVIDERS, MOCK_SOLICITANTES, MOCK_CATEGORIES, getCategoryNameById } from '../constants';
 import { Product } from '../types';
 
@@ -135,7 +136,7 @@ const DashboardPage: React.FC = () => {
 
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Dashboard</h1>
       <p className="text-lg text-gray-600 dark:text-slate-300">
         Bienvenido, <span className="font-semibold">{user?.username}</span>. Resumen del estado actual del sistema.
@@ -194,7 +195,7 @@ const DashboardPage: React.FC = () => {
            )}
         </Card>
       </div>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/ProfilePage.tsx
+++ b/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { Card } from '../components/ui/Card';
 import { Input } from '../components/ui/Input';
 import { Button } from '../components/ui/Button';
 import { Alert } from '../components/ui/Alert';
+import { MainContainer } from '../components/layout/MainContainer';
 
 const ProfilePage: React.FC = () => {
   const { user, login } = useAuth(); 
@@ -42,7 +43,7 @@ const ProfilePage: React.FC = () => {
   }
 
   return (
-    <div className="space-y-6 max-w-2xl mx-auto">
+    <MainContainer className="space-y-6 max-w-2xl">
       <h1 className="text-3xl font-bold text-gray-800">Mi Perfil</h1>
       
       <Card title="Información de Usuario">
@@ -82,7 +83,7 @@ const ProfilePage: React.FC = () => {
           </div>
         </form>
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/admin/AuditLogPage.tsx
+++ b/pages/admin/AuditLogPage.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
 import { MOCK_AUDIT_LOGS } from '../../constants';
 import { downloadCSV } from '../../utils/exportUtils';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'medium' });
@@ -74,7 +75,7 @@ const AuditLogPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800">Log de Auditoría del Sistema</h1>
       
       <Card title="Filtros de Búsqueda">
@@ -114,7 +115,7 @@ WARN: 2024-07-25 11:20:00 - BulkUpload: File 'categorias_viejas.csv' contained 3
         </pre>
          <Button variant="outline" className="mt-4" onClick={handleDownloadLog}>Descargar sistema.log</Button>
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/admin/SystemConfigPage.tsx
+++ b/pages/admin/SystemConfigPage.tsx
@@ -13,6 +13,7 @@ import { UserRole, SystemConfig } from '../../types';
 import { Navigate } from 'react-router-dom';
 import { logAuditEntry, MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_PROVIDERS, MOCK_CATEGORIES, MOCK_CONSUMPTIONS, MOCK_DOCUMENTS, MOCK_WORK_ORDERS, MOCK_MATERIAL_REQUESTS, MOCK_USERS, MOCK_AUDIT_LOGS, MOCK_ADJUSTMENTS } from '../../constants';
 import { downloadJSON, downloadCSV } from '../../utils/exportUtils';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const SystemConfigPage: React.FC = () => {
   const { user: currentUser } = useAuth();
@@ -120,7 +121,7 @@ const SystemConfigPage: React.FC = () => {
   const handleViewSystemInfo = () => setIsSystemInfoModalOpen(true);
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Configuración del Sistema</h1>
 
       {message && <Alert type={message.type} message={message.text} onClose={() => setMessage(null)} className="mb-4" />}
@@ -199,7 +200,7 @@ const SystemConfigPage: React.FC = () => {
             <Button onClick={() => setIsSystemInfoModalOpen(false)}>Cerrar</Button>
         </div>
       </Modal>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/admin/UserManagementPage.tsx
+++ b/pages/admin/UserManagementPage.tsx
@@ -10,6 +10,7 @@ import { PlusIcon, PencilIcon, TrashIcon, MOCK_USERS, logAuditEntry } from '../.
 import { useAuth } from '../../hooks/useAuth';
 import { Alert } from '../../components/ui/Alert';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const UserManagementPage: React.FC = () => {
   const { user: currentUser } = useAuth();
@@ -129,7 +130,7 @@ const UserManagementPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-800">Gestión de Usuarios</h1>
         <Button onClick={handleAddUser} leftIcon={<PlusIcon className="w-5 h-5" />}>
@@ -186,7 +187,7 @@ const UserManagementPage: React.FC = () => {
           </div>
         </div>
       </Modal>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/admin/UserRolesDescriptionPage.tsx
+++ b/pages/admin/UserRolesDescriptionPage.tsx
@@ -4,6 +4,7 @@ import { Card } from '../../components/ui/Card';
 import { UserRole } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const UserRolesDescriptionPage: React.FC = () => {
   const { user } = useAuth();
@@ -71,7 +72,7 @@ const UserRolesDescriptionPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Descripción de Roles de Usuario</h1>
       <p className="text-gray-600 dark:text-slate-300">
         A continuación se detalla qué puede hacer cada tipo de usuario en el sistema.
@@ -95,7 +96,7 @@ const UserRolesDescriptionPage: React.FC = () => {
           </div>
         </Card>
       ))}
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/bulk_upload/BulkUploadPage.tsx
+++ b/pages/bulk_upload/BulkUploadPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/ui/Button';
 import { Select } from '../../components/ui/Select';
 import { Alert } from '../../components/ui/Alert';
 import { ArrowUpTrayIcon, MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_PROVIDERS, MOCK_CATEGORIES } from '../../constants';
+import { MainContainer } from '../../components/layout/MainContainer';
 import { Product, Category, Provider } from '../../types';
 
 const BulkUploadPage: React.FC = () => {
@@ -292,7 +293,7 @@ const BulkUploadPage: React.FC = () => {
   }
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Carga Masiva de Datos</h1>
       
       {uploadStatus && <Alert type={uploadStatus.type} message={uploadStatus.message} onClose={() => setUploadStatus(null)} />}
@@ -364,7 +365,7 @@ const BulkUploadPage: React.FC = () => {
             </li>
         </ul>
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/consumptions/WorkOrderConsumptionPage.tsx
+++ b/pages/consumptions/WorkOrderConsumptionPage.tsx
@@ -11,7 +11,8 @@ import ConsumptionForm from '../../components/consumptions/ConsumptionForm';
 import { PlusIcon, EyeIcon, PencilIcon, TrashIcon, XCircleIcon, MOCK_USERS, logAuditEntry } from '../../constants';
 import { useAuth } from '../../hooks/useAuth';
 import { Alert } from '../../components/ui/Alert';
-import { MOCK_CONSUMPTIONS, MOCK_WORK_ORDERS, MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_SOLICITANTES } from '../../constants'; 
+import { MOCK_CONSUMPTIONS, MOCK_WORK_ORDERS, MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_SOLICITANTES } from '../../constants';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatDate = (dateString: string) => {
   if (!dateString) return 'N/A';
@@ -272,7 +273,7 @@ const WorkOrderConsumptionPage: React.FC = () => {
 
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h1 className="text-3xl font-bold text-gray-800">Consumos por Orden de Trabajo (OT)</h1>
         {canRecord && (
@@ -388,7 +389,7 @@ const WorkOrderConsumptionPage: React.FC = () => {
         </div>
       </Modal>
 
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/documents/DocumentListPage.tsx
+++ b/pages/documents/DocumentListPage.tsx
@@ -6,6 +6,7 @@ import { Input } from '../../components/ui/Input';
 import { Select } from '../../components/ui/Select';
 import { Table } from '../../components/ui/Table';
 import { Card } from '../../components/ui/Card';
+import { MainContainer } from '../../components/layout/MainContainer';
 import DocumentForm from '../../components/documents/DocumentForm';
 import { PlusIcon, EyeIcon, PaperClipIcon, XCircleIcon, MOCK_DOCUMENTS, MOCK_PROVIDERS, logAuditEntry } from '../../constants';
 import { useAuth } from '../../hooks/useAuth';
@@ -157,7 +158,7 @@ const DocumentListPage: React.FC = () => {
 
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h1 className="text-3xl font-bold text-gray-800">Documentos de Ingreso</h1>
         {canManage && (
@@ -207,7 +208,7 @@ const DocumentListPage: React.FC = () => {
           isReadOnly={!!viewingDocument && !canManage} // Admin/Manager can edit, others only view if documentData exists
         />
       )}
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/inventory/InventoryListPage.tsx
+++ b/pages/inventory/InventoryListPage.tsx
@@ -18,6 +18,7 @@ import {
 import { useAuth } from '../../hooks/useAuth';
 import { Alert } from '../../components/ui/Alert';
 import { Card } from '../../components/ui/Card';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatCurrency = (value: number) => {
   return new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value);
@@ -359,7 +360,7 @@ const InventoryListPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Gestión de Inventario</h1>
         <div className="flex space-x-3">
@@ -490,7 +491,7 @@ const InventoryListPage: React.FC = () => {
         </div>
       </Modal>
 
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/material_requests/MaterialRequestListPage.tsx
+++ b/pages/material_requests/MaterialRequestListPage.tsx
@@ -7,6 +7,7 @@ import { Select } from '../../components/ui/Select';
 import { Table } from '../../components/ui/Table';
 import { Modal } from '../../components/ui/Modal';
 import { Card } from '../../components/ui/Card';
+import { MainContainer } from '../../components/layout/MainContainer';
 import MaterialRequestForm from '../../components/material_requests/MaterialRequestForm';
 import { PlusIcon, EyeIcon, PencilIcon, TrashIcon, XCircleIcon, MOCK_SOLICITANTES, MOCK_MATERIAL_REQUESTS, MOCK_PROVIDERS, MOCK_DOCUMENTS, logAuditEntry } from '../../constants';
 import { useAuth } from '../../hooks/useAuth';
@@ -207,7 +208,7 @@ const MaterialRequestListPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Solicitudes de Materiales</h1>
         {canCreateMaterialRequests && (
@@ -278,7 +279,7 @@ const MaterialRequestListPage: React.FC = () => {
         </div>
       </Modal>
 
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/providers/ProviderListPage.tsx
+++ b/pages/providers/ProviderListPage.tsx
@@ -9,6 +9,7 @@ import ProviderForm from '../../components/providers/ProviderForm';
 import { PlusIcon, PencilIcon, TrashIcon, logAuditEntry } from '../../constants';
 import { useAuth } from '../../hooks/useAuth';
 import { Alert } from '../../components/ui/Alert';
+import { MainContainer } from '../../components/layout/MainContainer';
 import { MOCK_PROVIDERS } from '../../constants';
 
 const ProviderListPage: React.FC = () => {
@@ -154,7 +155,7 @@ const ProviderListPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Gestión de Proveedores</h1>
         {canManage && (
@@ -223,7 +224,7 @@ const ProviderListPage: React.FC = () => {
           </div>
         </div>
       </Modal>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/reports/InformeConsumosPage.tsx
+++ b/pages/reports/InformeConsumosPage.tsx
@@ -10,6 +10,7 @@ import { Table } from '../../components/ui/Table';
 import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatCurrency = (value: number) => new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value);
 const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString('es-CL');
@@ -121,7 +122,7 @@ const InformeConsumosPage: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800">Informe de Consumos</h1>
       {alertMessage && <Alert type={alertMessage.type} message={alertMessage.message} onClose={() => setAlertMessage(null)}/>}
       <Card title="Filtros del Informe">
@@ -153,7 +154,7 @@ const InformeConsumosPage: React.FC = () => {
         </div>
         <Table columns={columns} data={filteredData} keyExtractor={item => `${item.consumo_id}-${item.item_id}`} emptyMessage="No hay consumos que coincidan con los filtros." />
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/reports/InformeMovimientosPage.tsx
+++ b/pages/reports/InformeMovimientosPage.tsx
@@ -10,6 +10,7 @@ import { Table } from '../../components/ui/Table';
 import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatCurrency = (value: number | undefined) => value ? new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value) : 'N/A';
 const formatDate = (dateString: string) => new Date(dateString).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'medium' });
@@ -141,7 +142,7 @@ const InformeMovimientosPage: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800">Informe de Movimientos de Inventario</h1>
       {alertMessage && <Alert type={alertMessage.type} message={alertMessage.message} onClose={() => setAlertMessage(null)}/>}
       <Card title="Filtros del Informe">
@@ -165,7 +166,7 @@ const InformeMovimientosPage: React.FC = () => {
         </div>
         <Table columns={columns} data={filteredData} keyExtractor={item => item.id} emptyMessage="No hay movimientos que coincidan con los filtros." />
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/reports/InformePersonalizadoPage.tsx
+++ b/pages/reports/InformePersonalizadoPage.tsx
@@ -12,6 +12,7 @@ import { MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_CONSUMPTIONS, MOCK_DOCUMENTS, MOCK_
 import { downloadCSV, downloadExcel, downloadPDF } from '../../utils/exportUtils';
 import { Table } from '../../components/ui/Table';
 import { TableColumn } from '../../types';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 
 const InformePersonalizadoPage: React.FC = () => {
@@ -162,7 +163,7 @@ const InformePersonalizadoPage: React.FC = () => {
 
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Creador de Informes Personalizados</h1>
       {alertMessage && <Alert type={alertMessage.type} message={alertMessage.message} onClose={() => setAlertMessage(null)} />}
 
@@ -239,7 +240,7 @@ const InformePersonalizadoPage: React.FC = () => {
           </div>
         </div>
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/reports/InformeTiemposEsperaPage.tsx
+++ b/pages/reports/InformeTiemposEsperaPage.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
 import { MOCK_PROVIDERS, MOCK_DOCUMENTS, MOCK_WORK_ORDERS, XCircleIcon } from '../../constants';
 import { downloadCSV, downloadExcel, downloadPDF } from '../../utils/exportUtils';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 
 interface MockLeadTimeData {
@@ -151,7 +152,7 @@ const InformeTiemposEsperaPage: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800 dark:text-slate-100">Informe de Tiempos de Ciclo/Espera</h1>
       {alertMessage && <Alert type={alertMessage.type} message={alertMessage.message} onClose={() => setAlertMessage(null)} />}
       
@@ -184,7 +185,7 @@ const InformeTiemposEsperaPage: React.FC = () => {
         </div>
         <Table columns={columns} data={filteredData} keyExtractor={item => item.id} emptyMessage="No hay datos para el análisis seleccionado o filtros aplicados." />
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/reports/InformeValoracionStockPage.tsx
+++ b/pages/reports/InformeValoracionStockPage.tsx
@@ -9,6 +9,7 @@ import { Table } from '../../components/ui/Table';
 import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 const formatCurrency = (value: number) => new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value);
 
@@ -77,7 +78,7 @@ const InformeValoracionStockPage: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <h1 className="text-3xl font-bold text-gray-800">Informe de Valoración de Stock</h1>
       {alertMessage && <Alert type={alertMessage.type} message={alertMessage.message} onClose={() => setAlertMessage(null)}/>}
       <Card title="Filtros del Informe">
@@ -103,7 +104,7 @@ const InformeValoracionStockPage: React.FC = () => {
         </div>
         <Table columns={columns} data={filteredData} keyExtractor={item => item.id} emptyMessage="No hay productos que coincidan con los filtros." />
       </Card>
-    </div>
+    </MainContainer>
   );
 };
 

--- a/pages/requesters/RequesterListPage.tsx
+++ b/pages/requesters/RequesterListPage.tsx
@@ -10,6 +10,7 @@ import { PlusIcon, PencilIcon, TrashIcon, MOCK_SOLICITANTES, logAuditEntry } fro
 import { useAuth } from '../../hooks/useAuth';
 import { Alert } from '../../components/ui/Alert';
 import { Navigate } from 'react-router-dom';
+import { MainContainer } from '../../components/layout/MainContainer';
 
 
 const RequesterListPage: React.FC = () => {
@@ -124,7 +125,7 @@ const RequesterListPage: React.FC = () => {
   ];
 
   return (
-    <div className="space-y-6">
+    <MainContainer className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-800">Gestión de Solicitantes</h1>
         {canManage && (
@@ -183,7 +184,7 @@ const RequesterListPage: React.FC = () => {
           </div>
         </div>
       </Modal>
-    </div>
+    </MainContainer>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `MainContainer` layout component for centered content
- wrap main pages like Dashboard, Inventory, Reports etc. in `MainContainer`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d21f8088c832eb7fd5eb1678fa878