### PR TITLE
Implement token expiry and optional logger

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,43 +1,96 @@
 
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useState, useEffect, ReactNode, useRef } from 'react';
 import { User, UserRole } from '../types';
+import { useConfig } from './ConfigContext';
+import { logger } from '../utils/logger';
 
 interface AuthContextType {
   user: User | null;
+  token: string | null;
   login: (username: string, role: UserRole) => void;
   logout: () => void;
+  renewToken: () => void;
   loading: boolean;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { config } = useConfig();
   const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const expiryTimeoutRef = useRef<number>();
+
+  const scheduleExpiry = (expiresAt: number) => {
+    if (expiryTimeoutRef.current) {
+      window.clearTimeout(expiryTimeoutRef.current);
+    }
+    const timeout = expiresAt - Date.now();
+    if (timeout > 0) {
+      expiryTimeoutRef.current = window.setTimeout(() => {
+        logger.log('Session expired');
+        logout();
+      }, timeout);
+    }
+  };
 
   useEffect(() => {
     // Simulate checking for an existing session
     try {
       const storedUser = localStorage.getItem('authUser');
-      if (storedUser) {
-        setUser(JSON.parse(storedUser));
+      const storedToken = localStorage.getItem('authToken');
+      if (storedUser && storedToken) {
+        const parsedUser = JSON.parse(storedUser);
+        const parsedToken = JSON.parse(storedToken);
+        if (
+          parsedToken.token &&
+          typeof parsedToken.expiresAt === 'number' &&
+          Date.now() < parsedToken.expiresAt
+        ) {
+          setUser(parsedUser);
+          setToken(parsedToken.token);
+          scheduleExpiry(parsedToken.expiresAt);
+        } else {
+          localStorage.removeItem('authUser');
+          localStorage.removeItem('authToken');
+        }
       }
     } catch (error) {
-      console.error("Failed to parse auth user from localStorage", error);
+      logger.error('Failed to parse auth session from localStorage', error);
       localStorage.removeItem('authUser');
+      localStorage.removeItem('authToken');
     }
     setLoading(false);
   }, []);
 
   const login = (username: string, role: UserRole) => {
     const userData: User = { id: Date.now().toString(), username, role };
+    const newToken = Math.random().toString(36).substring(2);
+    const expiresAt = Date.now() + config.sessionTimeoutMinutes * 60 * 1000;
     setUser(userData);
+    setToken(newToken);
     localStorage.setItem('authUser', JSON.stringify(userData));
+    localStorage.setItem('authToken', JSON.stringify({ token: newToken, expiresAt }));
+    scheduleExpiry(expiresAt);
   };
 
   const logout = () => {
     setUser(null);
+    setToken(null);
+    if (expiryTimeoutRef.current) {
+      window.clearTimeout(expiryTimeoutRef.current);
+    }
     localStorage.removeItem('authUser');
+    localStorage.removeItem('authToken');
+  };
+
+  const renewToken = () => {
+    if (!token) return;
+    const expiresAt = Date.now() + config.sessionTimeoutMinutes * 60 * 1000;
+    localStorage.setItem('authToken', JSON.stringify({ token, expiresAt }));
+    scheduleExpiry(expiresAt);
+    logger.log('Session renewed');
   };
 
   if (loading) {
@@ -45,7 +98,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   }
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, loading }}>
+    <AuthContext.Provider value={{ user, token, login, logout, renewToken, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/contexts/ConfigContext.tsx
+++ b/contexts/ConfigContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useState, ReactNode, useContext, useCallback } from 'react';
 import { SystemConfig } from '../types';
 import { MOCK_SYSTEM_CONFIG } from '../constants';
+import { logger } from '../utils/logger';
 
 interface ConfigContextType {
   config: SystemConfig;
@@ -17,12 +18,12 @@ export const ConfigProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const setConfig = useCallback((newConfig: Partial<SystemConfig>) => {
     setInternalConfig(prevConfig => ({ ...prevConfig, ...newConfig }));
     // Here you might also persist to localStorage or an API in a real app
-    console.log("System config updated:", { ...config, ...newConfig });
+    logger.log('System config updated:', { ...config, ...newConfig });
   }, [config]);
 
   const resetConfig = useCallback(() => {
     setInternalConfig(MOCK_SYSTEM_CONFIG);
-    console.log("System config reset to default.");
+    logger.log('System config reset to default.');
   }, []);
 
   return (

--- a/pages/ProfilePage.tsx
+++ b/pages/ProfilePage.tsx
@@ -6,6 +6,7 @@ import { Input } from '../components/ui/Input';
 import { Button } from '../components/ui/Button';
 import { Alert } from '../components/ui/Alert';
 import { MainContainer } from '../components/layout/MainContainer';
+import { logger } from '../utils/logger';
 
 const ProfilePage: React.FC = () => {
   const { user, login } = useAuth(); 
@@ -30,7 +31,7 @@ const ProfilePage: React.FC = () => {
 
     // In real app, call API to change password.
     // For this demo, we don't actually store/check currentPassword.
-    console.log(`Password change attempt for ${user.username}. Current: ${currentPassword}, New: ${newPassword}`);
+    logger.log(`Password change attempt for ${user.username}. Current: ${currentPassword}, New: ${newPassword}`);
     
     setMessage({ type: 'success', text: 'Contraseña cambiada exitosamente.' });
     setCurrentPassword('');

--- a/pages/admin/SystemConfigPage.tsx
+++ b/pages/admin/SystemConfigPage.tsx
@@ -14,6 +14,7 @@ import { Navigate } from 'react-router-dom';
 import { logAuditEntry, MOCK_PRODUCTS_FOR_CONSUMPTION, MOCK_PROVIDERS, MOCK_CATEGORIES, MOCK_CONSUMPTIONS, MOCK_DOCUMENTS, MOCK_WORK_ORDERS, MOCK_MATERIAL_REQUESTS, MOCK_USERS, MOCK_AUDIT_LOGS, MOCK_ADJUSTMENTS } from '../../constants';
 import { downloadJSON, downloadCSV } from '../../utils/exportUtils';
 import { MainContainer } from '../../components/layout/MainContainer';
+import { logger } from '../../utils/logger';
 
 const SystemConfigPage: React.FC = () => {
   const { user: currentUser } = useAuth();
@@ -114,7 +115,7 @@ const SystemConfigPage: React.FC = () => {
       documents: MOCK_DOCUMENTS.length,
       consumptions: MOCK_CONSUMPTIONS.length,
     };
-    console.log('Diagnostics:', diagnostics);
+    logger.log('Diagnostics:', diagnostics);
     setMessage({ type: 'success', text: 'Diagnóstico completado. Sistema OK.' });
   }
   

--- a/pages/reports/InformeConsumosPage.tsx
+++ b/pages/reports/InformeConsumosPage.tsx
@@ -11,6 +11,7 @@ import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
 import { MainContainer } from '../../components/layout/MainContainer';
+import { logger } from '../../utils/logger';
 
 const formatCurrency = (value: number) => new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value);
 const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString('es-CL');
@@ -118,7 +119,7 @@ const InformeConsumosPage: React.FC = () => {
   const handleExport = (format: 'csv' | 'pdf' | 'excel') => {
     setAlertMessage({type: 'info', message: `Exportando datos a ${format.toUpperCase()}...`});
     // In a real app, this would trigger a file download with the filteredData
-    console.log(`Exporting Consumptions to ${format.toUpperCase()}:`, filteredData);
+    logger.log(`Exporting Consumptions to ${format.toUpperCase()}:`, filteredData);
   };
 
   return (

--- a/pages/reports/InformeMovimientosPage.tsx
+++ b/pages/reports/InformeMovimientosPage.tsx
@@ -11,6 +11,7 @@ import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
 import { MainContainer } from '../../components/layout/MainContainer';
+import { logger } from '../../utils/logger';
 
 const formatCurrency = (value: number | undefined) => value ? new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value) : 'N/A';
 const formatDate = (dateString: string) => new Date(dateString).toLocaleString('es-CL', { dateStyle: 'short', timeStyle: 'medium' });
@@ -138,7 +139,7 @@ const InformeMovimientosPage: React.FC = () => {
 
   const handleExport = (format: 'csv' | 'pdf' | 'excel') => {
     setAlertMessage({type: 'info', message: `Exportando datos a ${format.toUpperCase()}...`});
-    console.log(`Exporting Movements to ${format.toUpperCase()}:`, filteredData);
+    logger.log(`Exporting Movements to ${format.toUpperCase()}:`, filteredData);
   };
 
   return (

--- a/pages/reports/InformeValoracionStockPage.tsx
+++ b/pages/reports/InformeValoracionStockPage.tsx
@@ -10,6 +10,7 @@ import { Alert } from '../../components/ui/Alert';
 import { useAuth } from '../../hooks/useAuth';
 import { Navigate } from 'react-router-dom';
 import { MainContainer } from '../../components/layout/MainContainer';
+import { logger } from '../../utils/logger';
 
 const formatCurrency = (value: number) => new Intl.NumberFormat('es-CL', { style: 'currency', currency: 'CLP' }).format(value);
 
@@ -74,7 +75,7 @@ const InformeValoracionStockPage: React.FC = () => {
 
   const handleExport = (format: 'csv' | 'pdf' | 'excel') => {
      setAlertMessage({type: 'info', message: `Exportando datos a ${format.toUpperCase()}...`});
-     console.log(`Exporting Stock Valuation to ${format.toUpperCase()}:`, filteredData);
+     logger.log(`Exporting Stock Valuation to ${format.toUpperCase()}:`, filteredData);
   };
 
   return (

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,19 @@
+export const isLoggingEnabled = import.meta.env.VITE_ENABLE_LOGGING === 'true';
+
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (isLoggingEnabled) {
+      console.log(...args);
+    }
+  },
+  warn: (...args: unknown[]) => {
+    if (isLoggingEnabled) {
+      console.warn(...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    if (isLoggingEnabled) {
+      console.error(...args);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- support token expiry and renewal in `AuthContext`
- optional `logger` utility and clean up debug logging
- use logger in configuration and reports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d28aaaa1c832e8d71ff2b9990c6f5