### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm install --no-package-lock
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/output.css" />
+    <link rel="stylesheet" href="output.css" />
     <style>
       html {
         font-family: 'Inter', sans-serif;
@@ -18,6 +18,6 @@
    <body class="font-sans bg-neutral-light dark:bg-slate-900 text-gray-800 dark:text-slate-200">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+    <script type="module" src="index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "dev": "vite",
     "build": "vite build && npm run build:css",
     "build:css": "tailwindcss -i ./src/styles/global.css -o ./dist/output.css --minify",
-codex/instalar-jest-o-vitest-y-configurar-pruebas
-    "test": "vitest"
-
+    "test": "vitest",
     "server": "node server/index.js"
-main
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -38,5 +35,6 @@ main
     "typescript": "^5.8.3",
     "vite": "^7.0.3",
     "vitest": "^3.2.4"
-  }
+  },
+  "homepage": "https://<username>.github.io/north-chrome-ltda-gestion-de-bodega"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: '/north-chrome-ltda-gestion-de-bodega/',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- configure site base path in `vite.config.ts`
- reference built assets with relative paths
- fix `package.json` corruption and add GitHub Pages homepage
- add GitHub Actions workflow to deploy `dist` to `gh-pages`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d37b06bc0832ea39706cb7a008188