### PR TITLE
Update README with backend hosting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ main
 1.  Crea un nuevo sitio en Netlify y conecta este repositorio.
 2.  Netlify ejecutará `npm run build` utilizando `netlify.toml` y publicará el contenido de la carpeta `dist`.
 
+### Hospedaje del Backend
+
+El backend Express debe ejecutarse en un servicio aparte, ya que **GitHub Pages solo admite contenido estático**. Puedes desplegar la carpeta `server/` en plataformas que soporten Node.js, por ejemplo [Render](https://render.com/docs/deploy-node-express-app) o una función serverless en Netlify.
+
 ## Persistencia de Datos
 
 *   **Datos de la Aplicación**: Toda la información (productos, documentos, consumos, etc.) se almacena de forma persistente en MongoDB mediante el backend.
@@ -208,6 +212,7 @@ El código fuente está organizado en los siguientes directorios principales:
 
  codex/actualizar-readme-y-componentes-de-texto
 *   **Arquitectura Cliente-Servidor**: La aplicación se apoya en un backend Node.js que expone una API REST para todas las operaciones de inventario.
+*   **Backend por Separado**: El servidor Express debe hospedarse en un servicio externo y **no** puede ejecutarse en GitHub Pages.
 *   **Seguridad**: Las contraseñas se almacenan con hashing seguro y la autenticación utiliza tokens JWT con roles de usuario.
 *   **Exportación de Datos**: Los informes pueden exportarse a PDF, CSV o Excel desde la interfaz.
 *   **Escalabilidad**: El sistema persiste la información en MongoDB y puede ejecutarse en entornos de producción.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "dev": "vite",
     "build": "vite build && npm run build:css",
     "build:css": "tailwindcss -i ./src/styles/global.css -o ./dist/output.css --minify",
-codex/instalar-jest-o-vitest-y-configurar-pruebas
-    "test": "vitest"
-
+    "test": "vitest",
     "server": "node server/index.js"
-main
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- document that the Express backend must be deployed separately
- mention Render/Netlify for hosting
- fix invalid `package.json`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d37b0fe2c832e83f7475de4566161